### PR TITLE
TaskPaper regexes

### DIFF
--- a/PlainTasks.tmLanguage
+++ b/PlainTasks.tmLanguage
@@ -16,7 +16,7 @@
 
 		<dict>
 			<key>match</key>
-			<string>^\s*(\w+.+:\s*$\n?)</string>
+			<string>^\s*(\w+.+:\s*(\@[^\s]+(\(.*?\))?\s*)*$\n?)</string>
 			<key>name</key>
 			<string>keyword.control.header.todo</string>
 		</dict>
@@ -36,14 +36,14 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>^\s*(\+|✓|✔|☑)\s+((?:[^\@]|(?&lt;!\s)\@|\@(?=\s))*)</string>
+			<string>^\s*(\+|✓|✔|- ✔|☑)\s+((?:[^\@]|(?&lt;!\s)\@|\@(?=\s))*)</string>
 			<key>name</key>
 			<string>meta.item.todo.completed</string>
 		</dict>
 
 		<dict>
 		  <key>match</key>
-		  <string>^\s*((?!-|\+|✓|✔|❍|❑|■|□|☐|▪|▫|–|—|＿)\S).*((?!:\s*).\s*)$</string>
+		  <string>^\s*((?!-|\+|✓|✔|- ✔|❍|❑|■|□|☐|▪|▫|–|—|＿)\S).*((?!:\s*).\s*)$</string>
 		  <key>name</key>
 		  <string>notes.todo</string>
 		</dict>
@@ -70,14 +70,14 @@
 
 		<dict>
 			<key>match</key>
-			<string>(?&lt;=\s)(\@[\w\d\.\-!?]+\s+)*(\@done)[\(\)\d\w,\.:\-/\s]*\s*\n</string>
+			<string>(?&lt;=[\t\s])(\@[\w\d\.\-!?]+\s+)*(\@done)[\@\(\)\d\w,\.:\-/\s]*\s*\n</string>
 			<key>name</key>
 			<string>meta.tag.todo.completed</string>
 		</dict>
 
 		<dict>
 			<key>match</key>
-			<string>(?&lt;=\s)\@(?!today|completed|done)[\w\d\.\(\)\-!?]+\s*</string>
+			<string>(?&lt;=[\t\s])\@(?!today|completed|done)[\w\d\.\(\)\-!?]+\s*</string>
 			<key>name</key>
 			<string>meta.tag.todo</string>
 		</dict>


### PR DESCRIPTION
TaskPaper syntax allows for tags after the @done tag, as well as tags on projects. Added both to regexes.

Not sure if you had other intentions, but I really want to use this alongside TaskPaper. To that end I also removed the space that you put in between @done and (date). TaskPaper formats these as @done(xx-xx-xxxx). I didn't change that in this pull request, but you might consider it… at least as a preference option.
