### PR TITLE
Basic taskpaper compatibility

### DIFF
--- a/PlainTasks (Windows).sublime-settings
+++ b/PlainTasks (Windows).sublime-settings
@@ -1,6 +1,6 @@
 {
   "open_tasks_bullet": "☐", // options: - | ❍ | ❑ | ■ | □ | ☐ | ▪ | ▫ | – | — ≡ → ›
-  "done_tasks_bullet": "✔", // options: + | ✓ | ✔
+  "done_tasks_bullet": "✔", // options: - | + | ✓ | ✔
   "date_format": "(%y-%m-%d %H:%M)",
   "done_tag": true,
   "color_scheme": "Packages/PlainTasks/tasks.hidden-tmTheme",

--- a/PlainTasks.py
+++ b/PlainTasks.py
@@ -34,9 +34,9 @@ class NewCommand(SublimeTasksBase):
                 header = re.match('^(\s*)\S+', self.view.substr(line))
                 if header:
                     grps = header.groups()
-                    line_contents = self.view.substr(line) + '\n' + grps[0] + ' ' + self.open_tasks_bullet + ' '
+                    line_contents = self.view.substr(line) + '\n' + grps[0] + '\t' + self.open_tasks_bullet + ' '
                 else:
-                    line_contents = ' ' + self.open_tasks_bullet + ' '
+                    line_contents = '\t' + self.open_tasks_bullet + ' ' 
                 self.view.replace(edit, line, line_contents)
                 end = self.view.sel()[0].b
                 pt = sublime.Region(end, end)
@@ -50,7 +50,7 @@ class NewCommand(SublimeTasksBase):
                     line_contents = spaces + self.open_tasks_bullet + ' ' + grps[1]
                     self.view.replace(edit, line, line_contents)
                 else:
-                    line_contents = ' ' + self.open_tasks_bullet + ' ' + self.view.substr(line)
+                    line_contents = '\t' + self.open_tasks_bullet + ' ' + self.view.substr(line)
                     self.view.replace(edit, line, line_contents)
                     end = self.view.sel()[0].b
                     pt = sublime.Region(end, end)
@@ -61,25 +61,27 @@ class NewCommand(SublimeTasksBase):
 class CompleteCommand(SublimeTasksBase):
     def runCommand(self, edit):
         original = [r for r in self.view.sel()]
-        done_line_end = ' %s %s' % (self.done_tag, datetime.now().strftime(self.date_format))
+        done_line_end = ' %s%s' % (self.done_tag, datetime.now().strftime(self.date_format))
         offset = len(done_line_end)
         for region in self.view.sel():
             line = self.view.line(region)
             line_contents = self.view.substr(line).rstrip()
+
             rom = '^(\s*)' + re.escape(self.open_tasks_bullet) + '\s*(.*)$'
-            rdm = '^(\s*)' + re.escape(self.done_tasks_bullet) + '\s*([^\b]*?)\s*(%s)?[\(\)\d\w,\.:\-/ ]*\s*$' % self.done_tag
+            rdm = '^(\s*)' + re.escape(self.done_tasks_bullet) + '\s*([^\b]*?)\s*(%s)[\(\)\d\w,\.:\-/ ]*\s*$' % self.done_tag
+
             open_matches = re.match(rom, line_contents)
             done_matches = re.match(rdm, line_contents)
-            if open_matches:
-                grps = open_matches.groups()
-                self.view.insert(edit, line.end(), done_line_end)
-                replacement = u'%s%s %s' % (grps[0], self.done_tasks_bullet, grps[1].rstrip())
-                self.view.replace(edit, line, replacement)
-            elif done_matches:
+            if done_matches:
                 grps = done_matches.groups()
                 replacement = u'%s%s %s' % (grps[0], self.open_tasks_bullet, grps[1].rstrip())
                 self.view.replace(edit, line, replacement)
                 offset = -offset
+            elif open_matches:
+                grps = open_matches.groups()
+                self.view.insert(edit, line.end(), done_line_end)
+                replacement = u'%s%s %s' % (grps[0], self.done_tasks_bullet, grps[1].rstrip())
+                self.view.replace(edit, line, replacement)
         self.view.sel().clear()
         for ind, pt in enumerate(original):
             ofs = ind * offset
@@ -89,7 +91,7 @@ class CompleteCommand(SublimeTasksBase):
 
 class ArchiveCommand(SublimeTasksBase):
     def runCommand(self, edit):
-        rdm = '^(\s*)' + re.escape(self.done_tasks_bullet) + '\s*([^\b]*?)\s*(%s)?[\(\)\d\.:\-/ ]*[ \t]*$' % self.done_tag
+        rdm = '^(\s*)' + re.escape(self.done_tasks_bullet) + '\s*([^\b]*?)\s*(%s)[\(\)\d\.:\-/ ]*[ \t]*$' % self.done_tag
 
         # finding archive section
         archive_pos = self.view.find('Archive:', 0, sublime.LITERAL)

--- a/PlainTasks.tmLanguage
+++ b/PlainTasks.tmLanguage
@@ -34,12 +34,17 @@
 					<key>name</key>
 					<string>comment.line.completed.todo</string>
 				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>meta.tag.todo.completed</string>
+				</dict>
 			</dict>
 			<key>match</key>
-			<string>^\s*(\+|✓|✔|☑)\s+((?:[^\@]|(?&lt;!\s)\@|\@(?=\s))*)</string>
+			<string>^\s*(\+|-|✓|✔|☑)\s+([^\b]*?)\s*(\@done\(.*\)).*$</string>
 			<key>name</key>
 			<string>meta.item.todo.completed</string>
-		</dict>
+		</dict>	
 
 		<dict>
 		  <key>match</key>
@@ -70,14 +75,7 @@
 
 		<dict>
 			<key>match</key>
-			<string>(?&lt;=\s)(\@[\w\d\.\-!?]+\s+)*(\@done)[\(\)\d\w,\.:\-/\s]*\s*\n</string>
-			<key>name</key>
-			<string>meta.tag.todo.completed</string>
-		</dict>
-
-		<dict>
-			<key>match</key>
-			<string>(?&lt;=\s)\@(?!today|completed|done)[\w\d\.\(\)\-!?]+\s*</string>
+			<string>(?&lt;=\s)\@(?!today|completed|done)[\w\d\.\-!?]+(\(.*\))?</string>
 			<key>name</key>
 			<string>meta.tag.todo</string>
 		</dict>


### PR DESCRIPTION
Hi Aziz

First, thanks for this wonderfull plugin.

I intend to use it along w/ Taskpaper on iOS and made some slight changes to fit my needs.
You may find some of them undesirable but I hope this will pinpoint what needs to be changed.

It's not fully compatible yet, regarding the way the archive command works. 
Notes and subtasks are definitively not handled the same way in TP.

all the best
Waz

from commit msg:
- As TP use same bullet for both open and done tasks, the done tag had been made mandatory and is used to
- remove the space between done tag and date @done(2012-10-09)
- modify tags recognition in tmlanguage so that it accepts @tag & @tag(anything between braces)

Compatible settings :

```
{
    "open_tasks_bullet": "-",
    "done_tasks_bullet": "-",
    "date_format": "(%Y-%m-%d)", /*same date format as TP*/
    "done_tag": true, /*mandatory now*/
    "translate_tabs_to_spaces": false, /*TP uses tabs, not spaces*/
}
```
