### PR TITLE
Task bullet space added

### DIFF
--- a/PlainTasks (OSX).sublime-settings
+++ b/PlainTasks (OSX).sublime-settings
@@ -2,7 +2,6 @@
   "open_tasks_bullet": "☐", // options: - | ❍ | ❑ | ■ | □ | ☐ | ▪ | ▫ | – | — ≡ → ›
   "done_tasks_bullet": "✔", // options: + | ✓ | ✔
   "cancelled_tasks_bullet": "✘", // options: x | ✘
-  "tasks_bullet_space": " ",
   "before_tasks_bullet_margin": 1,
   "date_format": "(%y-%m-%d %H:%M)",
   "done_tag": true, // related to @cancelled as well

--- a/PlainTasks.py
+++ b/PlainTasks.py
@@ -16,8 +16,10 @@ class PlainTasksBase(sublime_plugin.TextCommand):
         self.open_tasks_bullet = self.view.settings().get('open_tasks_bullet')
         self.done_tasks_bullet = self.view.settings().get('done_tasks_bullet')
         self.canc_tasks_bullet = self.view.settings().get('cancelled_tasks_bullet')
-        self.tasks_bullet_space = self.view.settings().get('tasks_bullet_space')
-        self.before_tasks_bullet_spaces = self.tasks_bullet_space * self.view.settings().get('before_tasks_bullet_margin')
+        translate_tabs_to_spaces = self.view.settings().get('translate_tabs_to_spaces')
+        self.tasks_bullet_space = self.view.settings().get('tasks_bullet_space', ' ' if translate_tabs_to_spaces else '\t')
+        tasks_bullet_tab = (' ' * self.view.settings().get('tab_size')) if translate_tabs_to_spaces else '\t'
+        self.before_tasks_bullet_spaces = tasks_bullet_tab * self.view.settings().get('before_tasks_bullet_margin')
         self.date_format = self.view.settings().get('date_format')
         if self.view.settings().get('done_tag'):
             self.done_tag = "@done"


### PR DESCRIPTION
`tasks_bullet_space` allows setting the bullet and margin space type.
This makes it possible to fully use of tabs instead of spaces. For
instance, The following configuration will work nicely in PlainTasks:

``` json
{
    "tasks_bullet_space": "\t",
    "translate_tabs_to_spaces": false
}
```

Having a Tab as a separator allow the `done`, `cancelled` and `pending`
tasks to always align without "jumping" around when the state changes.
