### PR TITLE
Update regex expression to allow full path

### DIFF
--- a/PlainTasks.py
+++ b/PlainTasks.py
@@ -343,7 +343,7 @@ class PlainTasksOpenUrlCommand(sublime_plugin.TextCommand):
 
 
 class PlainTasksOpenLinkCommand(sublime_plugin.TextCommand):
-    LINK_PATTERN = re.compile(r'\.[\\/](?P<fn>[^\\/:*?"<>|]+)+[\\/]?(>(?P<sym>\w+))?(\:(?P<line>\d+))?(\:(?P<col>\d+))?(\"(?P<text>[^\n]*)\")?', re.I| re.U)
+    LINK_PATTERN = re.compile(r'\.[\\/](?P<fn>[^:*?"<>|]+)+[\\/]?(>(?P<sym>\w+))?(\:(?P<line>\d+))?(\:(?P<col>\d+))?(\"(?P<text>[^\n]*)\")?', re.I| re.U)
 
     def _format_res(self, res):
         return [res[0], "line: %d column: %d" % (int(res[1]), int(res[2]))]


### PR DESCRIPTION
The current behavior of `PlainTasksOpenLinkCommand` is to only allow a filename as the fn parameter. This change updates the regex to allow full paths as well, simply by removing '/' and '\' as stopping characters. 

This behavior is useful when a todo list is auto generated.
