### PR TITLE
Added a toggle tag, which can be used to toggle the time calculation

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -19,7 +19,8 @@
     [
       { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
       { "key": "selector", "operator": "equal", "operand": "text.todo" },
-      { "key": "preceding_text", "operator": "regex_contains", "operand": "@started(?!\\([\\d\\w,\\.:\\-\/ @]*\\))", "match_all": true }
+      { "key": "preceding_text", "operator": "regex_contains", "operand": "(@started|@toggle)(?!\\([\\d\\w,\\.:\\-\/ @]*\\))", "match_all": true }
+
     ]
   }
 ]

--- a/PlainTasks.py
+++ b/PlainTasks.py
@@ -8,6 +8,7 @@ import sublime_plugin
 import webbrowser
 import itertools
 from datetime import datetime
+from datetime import timedelta
 if int(sublime.version()) < 3000:
     import locale
 
@@ -104,6 +105,8 @@ class PlainTasksCompleteCommand(PlainTasksBase):
             '''  # rcm is the same, except bullet & ending
         rcm = r'^(\s*)(\[\-\]|.)(\s*[^\b]*?(?:[^\@]|(?<!\s)\@|\@(?=\s))*?\s*)(?=((?:\s@cancelled|@project|$).*)|(?:(\([^()]*\))\s*([^@]*|@project.*))?$)'
         started = r'^\s*[^\b]*?\s*@started(\([\d\w,\.:\-\/ @]*\)).*$'
+        toggle = r'@toggle(\([\d\w,\.:\-\/ @]*\))'
+
         regions = itertools.chain(*(reversed(self.view.lines(region)) for region in reversed(list(self.view.sel()))))
         for line in regions:
             line_contents = self.view.substr(line)
@@ -111,6 +114,8 @@ class PlainTasksCompleteCommand(PlainTasksBase):
             done_matches = re.match(rdm, line_contents, re.U)
             canc_matches = re.match(rcm, line_contents, re.U)
             started_matches = re.match(started, line_contents, re.U)
+            toggle_matches = re.findall(toggle,line_contents, re.U)
+
             current_scope = self.view.scope_name(line.a)
             if 'pending' in current_scope:
                 grps = open_matches.groups()
@@ -119,11 +124,11 @@ class PlainTasksCompleteCommand(PlainTasksBase):
                 self.view.replace(edit, line, replacement)
                 if started_matches:
                     eol -= len(grps[1]) - len(self.done_tasks_bullet)
-                    self.calc_end_start_time(self, edit, line, started_matches.group(1), done_line_end, eol)
+                    self.calc_end_start_time(self, edit, line, started_matches.group(1), toggle_matches, done_line_end, eol)
             elif 'header' in current_scope:
                 eol = self.view.insert(edit, line.end(), done_line_end)
                 if started_matches:
-                    self.calc_end_start_time(self, edit, line, started_matches.group(1), done_line_end, eol)
+                    self.calc_end_start_time(self, edit, line, started_matches.group(1), toggle_matches, done_line_end, eol)
                 indent = re.match('^(\s*)\S', line_contents, re.U)
                 self.view.insert(edit, line.begin() + len(indent.group(1)), '%s ' % self.done_tasks_bullet)
             elif 'completed' in current_scope:
@@ -148,10 +153,16 @@ class PlainTasksCompleteCommand(PlainTasksBase):
         PlainTasksStatsStatus.set_stats(self.view)
 
     @staticmethod
-    def calc_end_start_time(self, edit, line, started_matches, done_line_end, eol, tag='lasted'):
+    def calc_end_start_time(self, edit, line, started_matches,toggle_matches,done_line_end, eol, tag='lasted'):
         start = datetime.strptime(started_matches, self.date_format)
         end = datetime.strptime(done_line_end.replace('@done', '').replace('@cancelled', '').strip(), self.date_format)
-        delta = str(end - start)
+
+        toggle_times = [datetime.strptime(toggle,self.date_format) for toggle in toggle_matches];
+        all_times = [start] + toggle_times + [end];
+        pairs = zip(all_times[::2], all_times[1::2]);
+        deltas = [pair[1] - pair[0] for pair in pairs]
+
+        delta = str(sum(deltas,timedelta()))
         if delta[~2:] == ':00': # strip meaningless seconds
             delta = delta[:~2]
         self.view.insert(edit, line.end() + eol, ' @%s(%s)' % (tag, delta))
@@ -183,6 +194,7 @@ class PlainTasksCancelCommand(PlainTasksBase):
         rdm = r'^(\s*)(\[x\]|.)(\s*[^\b]*?(?:[^\@]|(?<!\s)\@|\@(?=\s))*?\s*)(?=((?:\s@done|@project|$).*)|(?:(\([^()]*\))\s*([^@]*|@project.*))?$)'
         rcm = r'^(\s*)(\[\-\]|.)(\s*[^\b]*?(?:[^\@]|(?<!\s)\@|\@(?=\s))*?\s*)(?=((?:\s@cancelled|@project|$).*)|(?:(\([^()]*\))\s*([^@]*|@project.*))?$)'
         started = '^\s*[^\b]*?\s*@started(\([\d\w,\.:\-\/ @]*\)).*$'
+        toggle = r'@toggle(\([\d\w,\.:\-\/ @]*\))'
         regions = itertools.chain(*(reversed(self.view.lines(region)) for region in reversed(list(self.view.sel()))))
         for line in regions:
             line_contents = self.view.substr(line)
@@ -190,6 +202,8 @@ class PlainTasksCancelCommand(PlainTasksBase):
             done_matches = re.match(rdm, line_contents, re.U)
             canc_matches = re.match(rcm, line_contents, re.U)
             started_matches = re.match(started, line_contents, re.U)
+            toggle_matches = re.findall(toggle,line_contents, re.U)
+
             current_scope = self.view.scope_name(line.a)
             if 'pending' in current_scope:
                 grps = open_matches.groups()
@@ -198,11 +212,11 @@ class PlainTasksCancelCommand(PlainTasksBase):
                 self.view.replace(edit, line, replacement)
                 if started_matches:
                     eol -= len(grps[1]) - len(self.canc_tasks_bullet)
-                    PlainTasksCompleteCommand.calc_end_start_time(self, edit, line, started_matches.group(1), canc_line_end, eol, tag='wasted')
+                    PlainTasksCompleteCommand.calc_end_start_time(self, edit, line, started_matches.group(1), toggle_matches, canc_line_end, eol, tag='wasted')
             elif 'header' in current_scope:
                 eol = self.view.insert(edit, line.end(), canc_line_end)
                 if started_matches:
-                    PlainTasksCompleteCommand.calc_end_start_time(self, edit, line, started_matches.group(1), canc_line_end, eol, tag='wasted')
+                    PlainTasksCompleteCommand.calc_end_start_time(self, edit, line, started_matches.group(1), toggle_matches, canc_line_end, eol, tag='wasted')
                 indent = re.match('^(\s*)\S', line_contents, re.U)
                 self.view.insert(edit, line.begin() + len(indent.group(1)), '%s ' % self.canc_tasks_bullet)
             elif 'completed' in current_scope:

--- a/PlainTasks.sublime-completions
+++ b/PlainTasks.sublime-completions
@@ -2,6 +2,7 @@
     "scope": "text.todo",
     "completions": [
         { "trigger": "s", "contents": "@started" },
-        { "trigger": "t", "contents": "@today" }
+        { "trigger": "t", "contents": "@today" },
+        { "trigger": "to", "contents": "@toggle"}
     ]
 }


### PR DESCRIPTION
Use the toggle tag to toggle the time calculation on and off (like a stopwatch) for the tasks @lasted calculation. Here's an example:

TimeTests:

```
✔ two toggle middle @started(14-10-12 12:00) @toggle(14-10-12 12:30) @toggle(14-10-12 14:30) @done (14-10-12 15:25) @lasted(1:25)
✔ one toggle start @started(14-10-12 12:00) @toggle(14-10-12 12:00) @done (14-10-12 15:27) @lasted(0:00)
✔ one toggle end @started(14-10-12 12:00) @toggle(14-10-12 15:28) @done (14-10-12 15:28) @lasted(3:28)
✔ one toggle middle @started(14-10-12 12:00) @toggle(14-10-12 13:00) @done (14-10-12 15:58) @lasted(1:00)
✔ three toggles @started(14-10-12 12:00) @toggle(14-10-12 12:30) @toggle(14-10-12 14:30) @toggle(14-10-12 15:00) @done (14-10-12 16:05) @lasted(1:00)
✔ four toggles @started(14-10-12 12:00) @toggle(14-10-12 12:30) @toggle(14-10-12 14:30) @toggle(14-10-12 15:00) @toggle(14-10-12 16:00) @done (14-10-12 16:07) @lasted(1:07)
✔ zero toggles @started(14-10-12 12:00) @done (14-10-12 16:09) @lasted(4:09)
```
