### PR TITLE
Don't use "horrible" color/font/font-size schemes by default.

### DIFF
--- a/PlainTasks (Linux).sublime-settings
+++ b/PlainTasks (Linux).sublime-settings
@@ -10,7 +10,7 @@
   "indent_after_task": true, // indenting the next line after tasks
   "new_on_top": true, // how to sort archived tasks
 
-  "color_scheme": "Packages/PlainTasks/tasks.hidden-tmTheme",
+  // "color_scheme": "Packages/PlainTasks/tasks.hidden-tmTheme",
     // other bundled schemes:
     //   Packages/PlainTasks/tasks-dark.hidden-tmTheme
     //   Packages/PlainTasks/tasks-eighties-dark.hidden-tmTheme
@@ -18,8 +18,8 @@
     //   Packages/PlainTasks/tasks-monokai.hidden-tmTheme
     //   Packages/PlainTasks/tasks-solarized-dark.hidden-tmTheme
     //   Packages/PlainTasks/tasks-solarized-light.hidden-tmTheme
-  "font_size": 15,
-  "font_face": "Consolas",
+  // "font_size": 15,
+  // "font_face": "Consolas",
   "draw_indent_guides": false,
   "line_numbers": false,
   "gutter": true,

--- a/PlainTasks (OSX).sublime-settings
+++ b/PlainTasks (OSX).sublime-settings
@@ -10,7 +10,7 @@
   "indent_after_task": true, // indenting the next line after tasks
   "new_on_top": true, // how to sort archived tasks
 
-  "color_scheme": "Packages/PlainTasks/tasks.hidden-tmTheme",
+  // "color_scheme": "Packages/PlainTasks/tasks.hidden-tmTheme",
     // other bundled schemes:
     //   Packages/PlainTasks/tasks-dark.hidden-tmTheme
     //   Packages/PlainTasks/tasks-eighties-dark.hidden-tmTheme
@@ -18,8 +18,8 @@
     //   Packages/PlainTasks/tasks-monokai.hidden-tmTheme
     //   Packages/PlainTasks/tasks-solarized-dark.hidden-tmTheme
     //   Packages/PlainTasks/tasks-solarized-light.hidden-tmTheme
-  "font_size": 15,
-  "font_face": "Consolas",
+  // "font_size": 15,
+  // "font_face": "Consolas",
   "draw_indent_guides": false,
   "line_numbers": false,
   "gutter": true,

--- a/PlainTasks (Windows).sublime-settings
+++ b/PlainTasks (Windows).sublime-settings
@@ -10,7 +10,7 @@
   "indent_after_task": true, // indenting the next line after tasks
   "new_on_top": true, // how to sort archived tasks
 
-  "color_scheme": "Packages/PlainTasks/tasks.hidden-tmTheme",
+  // "color_scheme": "Packages/PlainTasks/tasks.hidden-tmTheme",
     // other bundled schemes:
     //   Packages/PlainTasks/tasks-dark.hidden-tmTheme
     //   Packages/PlainTasks/tasks-eighties-dark.hidden-tmTheme
@@ -18,8 +18,8 @@
     //   Packages/PlainTasks/tasks-monokai.hidden-tmTheme
     //   Packages/PlainTasks/tasks-solarized-dark.hidden-tmTheme
     //   Packages/PlainTasks/tasks-solarized-light.hidden-tmTheme
-  "font_size": 11,
-  "font_face": "Consolas",
+  // "font_size": 11,
+  // "font_face": "Consolas",
   "draw_indent_guides": false,
   "line_numbers": false,
   "gutter": true,


### PR DESCRIPTION
If they are not set by default, global sublime settings are used, which is
good for some users (me). This settings can't be changed in user settings
to be ignored (so the global settings would be used), you can only change
them to something else, but never to the global defaults.

I am really tired of editing PlainTasks default file, which keep changing
after each update back.
