### PR TITLE
Added Org-Mode style archive command

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -4,6 +4,8 @@
   { "keys": ["ctrl+enter"], "command": "plain_tasks_new","context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }] },
   { "keys": ["ctrl+i"], "command": "plain_tasks_new","context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }] },
   { "keys": ["ctrl+shift+a"], "command": "plain_tasks_archive","context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }] },
+  { "keys": ["ctrl+shift+o"], "command": "plain_tasks_archive_org","context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }] },
+  { "keys": ["ctrl+shift+u"], "command": "plain_tasks_open_url","context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }] },
   { "keys": ["ctrl+shift+u"], "command": "plain_tasks_open_url","context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }] },
   { "keys": ["alt+o"], "command": "plain_tasks_open_link","context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }] },
   { "keys": ["enter"], "command": "insert", "args": {"characters": "\n\t"}, "context":

--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -17,11 +17,18 @@
       { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[-|+|✓|✔|❍|❑|■|□|☐|▪|▫|–|—|✘|x]\\s+.+", "match_all": true }
     ]
   },
+  { "keys": ["tab"], "command": "plain_task_insert_date_only", "context":
+    [
+      { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+      { "key": "selector", "operator": "equal", "operand": "text.todo" },
+      { "key": "preceding_text", "operator": "regex_contains", "operand": "(@date)(?!\\([\\d\\w,\\.:\\-\/ @]*\\))", "match_all": true }
+    ]
+  },
   { "keys": ["tab"], "command": "plain_task_insert_date", "context":
     [
       { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
       { "key": "selector", "operator": "equal", "operand": "text.todo" },
-      { "key": "preceding_text", "operator": "regex_contains", "operand": "(@started|@toggle|@created)(?!\\([\\d\\w,\\.:\\-\/ @]*\\))", "match_all": true }
+      { "key": "preceding_text", "operator": "regex_contains", "operand": "(@now|@started|@toggle|@created)(?!\\([\\d\\w,\\.:\\-\/ @]*\\))", "match_all": true }
     ]
   },
   { "keys": ["tab"], "command": "plain_tasks_replace_short_date", "context":

--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -6,7 +6,6 @@
   { "keys": ["ctrl+shift+a"], "command": "plain_tasks_archive","context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }] },
   { "keys": ["ctrl+shift+o"], "command": "plain_tasks_archive_org","context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }] },
   { "keys": ["ctrl+shift+u"], "command": "plain_tasks_open_url","context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }] },
-  { "keys": ["ctrl+shift+u"], "command": "plain_tasks_open_url","context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }] },
   { "keys": ["alt+o"], "command": "plain_tasks_open_link","context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }] },
   { "keys": ["enter"], "command": "insert", "args": {"characters": "\n\t"}, "context":
     [

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -17,11 +17,18 @@
       { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[-|+|✓|✔|❍|❑|■|□|☐|▪|▫|–|—|✘|x]\\s+.+$", "match_all": true }
     ]
   },
+  { "keys": ["tab"], "command": "plain_task_insert_date_only", "context":
+    [
+      { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+      { "key": "selector", "operator": "equal", "operand": "text.todo" },
+      { "key": "preceding_text", "operator": "regex_contains", "operand": "(@date)(?!\\([\\d\\w,\\.:\\-\/ @]*\\))", "match_all": true }
+    ]
+  },
   { "keys": ["tab"], "command": "plain_task_insert_date", "context":
     [
       { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
       { "key": "selector", "operator": "equal", "operand": "text.todo" },
-      { "key": "preceding_text", "operator": "regex_contains", "operand": "(@started|@toggle|@created)(?!\\([\\d\\w,\\.:\\-\/ @]*\\))", "match_all": true }
+      { "key": "preceding_text", "operator": "regex_contains", "operand": "(@now|@started|@toggle|@created)(?!\\([\\d\\w,\\.:\\-\/ @]*\\))", "match_all": true }
     ]
   },
   { "keys": ["tab"], "command": "plain_tasks_replace_short_date", "context":

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -5,7 +5,6 @@
   { "keys": ["super+i"], "command": "plain_tasks_new","context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }] },
   { "keys": ["super+shift+a"], "command": "plain_tasks_archive","context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }] },
   { "keys": ["super+shift+o"], "command": "plain_tasks_archive_org","context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }] },
-  { "keys": ["ctrl+shift+u"], "command": "plain_tasks_open_url","context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }] },
   { "keys": ["super+shift+u"], "command": "plain_tasks_open_url","context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }] },
   { "keys": ["ctrl+o"], "command": "plain_tasks_open_link","context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }] },
   { "keys": ["enter"], "command": "insert", "args": {"characters": "\n\t"}, "context":

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -4,6 +4,8 @@
   { "keys": ["super+enter"], "command": "plain_tasks_new","context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }] },
   { "keys": ["super+i"], "command": "plain_tasks_new","context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }] },
   { "keys": ["super+shift+a"], "command": "plain_tasks_archive","context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }] },
+  { "keys": ["super+shift+o"], "command": "plain_tasks_archive_org","context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }] },
+  { "keys": ["ctrl+shift+u"], "command": "plain_tasks_open_url","context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }] },
   { "keys": ["super+shift+u"], "command": "plain_tasks_open_url","context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }] },
   { "keys": ["ctrl+o"], "command": "plain_tasks_open_link","context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }] },
   { "keys": ["enter"], "command": "insert", "args": {"characters": "\n\t"}, "context":

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -4,6 +4,7 @@
   { "keys": ["ctrl+enter"], "command": "plain_tasks_new","context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }] },
   { "keys": ["ctrl+i"], "command": "plain_tasks_new","context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }] },
   { "keys": ["ctrl+shift+a"], "command": "plain_tasks_archive","context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }] },
+  { "keys": ["ctrl+shift+o"], "command": "plain_tasks_archive_org","context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }] },
   { "keys": ["ctrl+shift+u"], "command": "plain_tasks_open_url","context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }] },
   { "keys": ["alt+o"], "command": "plain_tasks_open_link","context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }] },
   { "keys": ["enter"], "command": "insert", "args": {"characters": "\n\t"}, "context":

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -17,11 +17,18 @@
       { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[-|+|✓|✔|❍|❑|■|□|☐|▪|▫|–|—|✘|x]\\s+.+", "match_all": true }
     ]
   },
+  { "keys": ["tab"], "command": "plain_task_insert_date_only", "context":
+    [
+      { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+      { "key": "selector", "operator": "equal", "operand": "text.todo" },
+      { "key": "preceding_text", "operator": "regex_contains", "operand": "(@date)(?!\\([\\d\\w,\\.:\\-\/ @]*\\))", "match_all": true }
+    ]
+  },
   { "keys": ["tab"], "command": "plain_task_insert_date", "context":
     [
       { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
       { "key": "selector", "operator": "equal", "operand": "text.todo" },
-      { "key": "preceding_text", "operator": "regex_contains", "operand": "(@started|@toggle|@created)(?!\\([\\d\\w,\\.:\\-\/ @]*\\))", "match_all": true }
+      { "key": "preceding_text", "operator": "regex_contains", "operand": "(@now|@started|@toggle|@created)(?!\\([\\d\\w,\\.:\\-\/ @]*\\))", "match_all": true }
     ]
   },
   { "keys": ["tab"], "command": "plain_tasks_replace_short_date", "context":

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -4,7 +4,7 @@
     { "caption": "Tasks: Cancel", "command": "plain_tasks_cancel" },
     { "caption": "Tasks: New", "command": "plain_tasks_new" },
     { "caption": "Tasks: Archive", "command": "plain_tasks_archive" },
-    { "caption": "Tasks: OrgMode Archive", "command": "plain_tasks_org_archive" },
+    { "caption": "Tasks: Archive (Org-Mode Style)", "command": "plain_tasks_org_archive" },
     { "caption": "Tasks: Open URL", "command": "plain_tasks_open_url" },
     { "caption": "Tasks: Open Link", "command": "plain_tasks_open_link" },
     { "caption": "Tasks: View as HTML", "command": "plain_tasks_convert_to_html" },

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -4,6 +4,7 @@
     { "caption": "Tasks: Cancel", "command": "plain_tasks_cancel" },
     { "caption": "Tasks: New", "command": "plain_tasks_new" },
     { "caption": "Tasks: Archive", "command": "plain_tasks_archive" },
+    { "caption": "Tasks: OrgMode Archive", "command": "plain_tasks_org_archive" },
     { "caption": "Tasks: Open URL", "command": "plain_tasks_open_url" },
     { "caption": "Tasks: Open Link", "command": "plain_tasks_open_link" },
     { "caption": "Tasks: View as HTML", "command": "plain_tasks_convert_to_html" },

--- a/PlainTasks.py
+++ b/PlainTasks.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-import os
+import os,io
 import re
 import sublime
 import sublime_plugin
@@ -714,7 +714,7 @@ class PlainTasksConvertToHtml(PlainTasksBase):
             html_doc.append(ht)
 
         # create file
-        import tempfile, io
+        import tempfile
         tmp_html = tempfile.NamedTemporaryFile(delete=False, suffix='.html')
         with io.open('%s/PlainTasks/templates/template.html' % sublime.packages_path(), 'r', encoding='utf8') as template:
             title = os.path.basename(self.view.file_name()) if self.view.file_name() else 'Export'
@@ -867,11 +867,10 @@ class PlainTasksArchiveOrgCommand(PlainTasksBase):
         start_region=self.view.line(self.view.text_point(start_line,0))
         region=start_region.cover(self.view.line(
             self.view.text_point(end_line,0)))
-        #sublime.message_dialog("Debug:\n\nWriting: Region:({},{})".format(
-        #    region.a, region.b))
         # Write it out!
+        sublime.status_message('Archiving tree to {}'.format(filename))
         try:
-            with open (filename, "a") as fh:
+            with io.open(filename, 'a', encoding='utf8') as fh:
                 data = self.view.substr(region)
                 fh.write("--- ✄ -----------------------\n")
                 fh.write("Archived {}:\n".format(datetime.now().strftime(
@@ -882,7 +881,6 @@ class PlainTasksArchiveOrgCommand(PlainTasksBase):
             sublime.error_message("Error:\n\nUnable to append to {}\n{}".format(
                 filename, str(e)))
             return False, None
-
 
     def __createArchiveFilename(self):
         # Compute archive filename

--- a/PlainTasks.py
+++ b/PlainTasks.py
@@ -41,8 +41,6 @@ class PlainTasksBase(sublime_plugin.TextCommand):
         self.archive_org_default_filemask = "{dir}{sep}{base}_archive{ext}"
         self.archive_org_filemask = self.view.settings().get(
                 'archive_org_filemask', self.archive_org_default_filemask)
-        self.archive_org_use_file = self.view.settings().get(
-                'archive_org_use_file', True)
         self.runCommand(edit)
 
 

--- a/PlainTasks.py
+++ b/PlainTasks.py
@@ -28,6 +28,7 @@ class PlainTasksBase(sublime_plugin.TextCommand):
         self.before_tasks_bullet_spaces = ' ' * self.view.settings().get('before_tasks_bullet_margin', 1) if not self.taskpaper_compatible and translate_tabs_to_spaces else '\t'
         self.tasks_bullet_space = self.view.settings().get('tasks_bullet_space', ' ' if self.taskpaper_compatible or translate_tabs_to_spaces else '\t')
         self.date_format = self.view.settings().get('date_format', '(%y-%m-%d %H:%M)')
+        self.date_only_format = self.view.settings().get('date_only_format', '(%d-%b-%Y)')
         if self.view.settings().get('done_tag', True) or self.taskpaper_compatible:
             self.done_tag = "@done"
             self.canc_tag = "@cancelled"
@@ -505,6 +506,10 @@ class PlainTaskInsertDate(PlainTasksBase):
         for s in reversed(list(self.view.sel())):
             self.view.insert(edit, s.b, datetime.now().strftime(self.date_format))
 
+class PlainTaskInsertDateOnly(PlainTasksBase):
+    def runCommand(self, edit):
+        for s in reversed(list(self.view.sel())):
+            self.view.insert(edit, s.b, datetime.now().strftime(self.date_only_format))
 
 class PlainTasksReplaceShortDate(PlainTasksBase):
     def runCommand(self, edit):

--- a/PlainTasks.sublime-completions
+++ b/PlainTasks.sublime-completions
@@ -8,6 +8,8 @@
   { "trigger": "s\t@started", "contents": "@started" },
   { "trigger": "tg\t@toggle", "contents": "@toggle"},
   { "trigger": "d\t@due()", "contents": "@due( $0)"},
-  { "trigger": "cr\t@created", "contents": "@created"}
+  { "trigger": "cr\t@created", "contents": "@created"},
+  { "trigger": "da\t@date", "contents": "@date"},
+  { "trigger": "no\t@now", "contents": "@now"},
  ]
 }


### PR DESCRIPTION
I've moved from org-mode to PlainTasks (Thanks!).  But, one of the things I missed was the ability to archive off old stuff into a file.

And, by old stuff, I mean trees, not just todos.  When I take meeting notes, for instance, I create something like this:

Meeting A (datestamp)
  Agenda
    Whatever
  Notes
    Whatever
    [] With a Todo
  Todos
     [] and more todos

What I wanted was the ability to put my cursor on Meeting A, and dump the whole thing to an archive.

For now, I also went with an archive file, instead of a part of the existing document.  However, I could leverage your code and do it your way, too.

I tried to comment it pretty well.  Let me know if you have any questions.

-Dave