### PR TITLE
Make it easier to start a new todo-list

### DIFF
--- a/messages/Tutorial.todo
+++ b/messages/Tutorial.todo
@@ -8,6 +8,9 @@ Projects:
 Tasks:
   You can write plain text as _notes_ or descriptions wherever you want;
   It’s **totally** fine!
+  Starting a new todo-list:
+   ☐ Bring up the command palette (it's ⌘+shift+p in Mac and ctrl+shift+p in Windows)
+   ☐ type `task` and select `Tasks: New document` command
   New:
    ☐ ⌘+enter (ctrl+enter on Windows) adds a new task.
    ☐ ⌘+i (ctrl+i on Windows) also adds a new task
@@ -58,10 +61,6 @@ Tasks:
    ☐ ⌘+shift+O (ctrl+shift+O) will archive in Org-Mode style.
       Removing the entire subtree after cursor and appending it to new file next to original one,
       e.g. filename.TODO → filename_archive.TODO
-
-  Starting a new todo-list:
-   ☐ Bring up the command palette (it's ⌘+shift+p in Mac and ctrl+shift+p in Windows)
-   ☐ type `task` and select `Tasks: New document` command
 
 --- ✄ -----------------------
 You can use separator snippet to separate your todo lists, type -- and press tab

--- a/messages/Tutorial.todo
+++ b/messages/Tutorial.todo
@@ -11,6 +11,7 @@ Tasks:
   Starting a new todo-list:
    ☐ Bring up the command palette (it's ⌘+shift+p in Mac and ctrl+shift+p in Windows)
    ☐ type `task` and select `Tasks: New document` command
+   You can also turn on the syntax highlighting (and keyboard shortcuts) by turning on the `tasks` syntax.
   New:
    ☐ ⌘+enter (ctrl+enter on Windows) adds a new task.
    ☐ ⌘+i (ctrl+i on Windows) also adds a new task


### PR DESCRIPTION
While reading through this & trying out the tutorial, I didn't understand why the example keyboard shortcuts weren't working.

This is because I wasn't using the `Tasks` syntax.

I moved those instructions higher in the tutorial, since creating a new tasks file is frequently the first thing one wants to do.