### PR TITLE
Tags are non-greedy and accept anything within balanced brackets

### DIFF
--- a/PlainTasks.sublime-syntax
+++ b/PlainTasks.sublime-syntax
@@ -87,7 +87,7 @@ contexts:
     - match: (?<=\s)\@low|✭low
       scope: string.other.tag.todo.low
   tag:
-    - match: '(?<=\s)\@(?!(high|today|critical|low|completed|done)[\s\(])[\w\d\.\(\)\-!? :\+]+[ \t]*'
+    - match: '(?<=\s)\@(?!(high|today|critical|low|completed|done)[\s\(])\w*(\((?>[^()]|(\g<1>))*+\))++[ \t]*'
       scope: meta.tag.todo
   today:
     - match: (?<=\s)\@today|✭ᴛᴏᴅᴀʏ

--- a/PlainTasks.sublime-syntax
+++ b/PlainTasks.sublime-syntax
@@ -87,7 +87,7 @@ contexts:
     - match: (?<=\s)\@low|✭low
       scope: string.other.tag.todo.low
   tag:
-    - match: '(?<=\s)\@(?!(high|today|critical|low|completed|done)[\s\(])\w*(\((?>[^()]|(\g<1>))*+\))++[ \t]*'
+    - match: '(?<=\s)\@(?!(high|today|critical|low|completed|done)[\s\(])\w+(\((?>[^()]|(\g<2>))*+\))*+[ \t]*'
       scope: meta.tag.todo
   today:
     - match: (?<=\s)\@today|✭ᴛᴏᴅᴀʏ


### PR DESCRIPTION
Title. You can now embed tags within a task, like @tag here, and it won't highlight the rest of the line.
Special tags (@critical) function as normal.

This does mean that tags like @due now highlights any character within the brackets but this can be changed. The highlighting matches the first balanced bracket after due and everything inbetween.

I haven't changed the .tmLanguage file that might (?) need updating