### PR TITLE
Add command: "Fold to tasks due next"

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -12,5 +12,6 @@
     { "caption": "Tasks: Save as HTML…", "command": "plain_tasks_convert_to_html", "args": {"ask": true} },
     { "caption": "Tasks: Copy Statistics", "command": "plain_tasks_copy_stats" },
     { "caption": "Tasks: Fold to due tasks", "command": "plain_tasks_fold_to_due_tags" },
+    { "caption": "Tasks: Fold to tasks due next", "command": "plain_tasks_fold_due_next_tags" },
     { "caption": "Tasks: Filter by tags under cursors", "command": "plain_tasks_fold_to_tags" }
 ]


### PR DESCRIPTION
I try to schedule myself on a "work on the next task due next".

This is easy to satisfy when I have some overdue/upcoming tasks -- just use `Tasks: Fold to due tasks`, and select the most-overdue tasks first.

However, this isn't as easy when I'm ahead of myself (I try to stay ahead of my due dates). Because of this, I try to grab things that I don't need to do until then.

## Implementation/Decisions.
* Shamelessly, I copy-pasted most of the `due_soon` implementation, collecting "interesting" (aka parsed) `(due timestamp, line)` tuples, and sorted/took the first 10 at the end.
* There's a TODO in there about setting up a sample value -- I'm not sure if there's a Default settings file I need to add the new settings to.
* Most of the settings for the `next_tasks` fallback to the `due_soon` values instead of having their own defaults.
