### PR TITLE
Add ability to shorten urls

### DIFF
--- a/PlainTasks.py
+++ b/PlainTasks.py
@@ -764,6 +764,9 @@ class PlainTasksShortenURL(sublime_plugin.EventListener):
         self.fold_all_urls(view)
 
     def fold_all_urls(self, view):
+        if not view.settings().get('shorten_urls', False):
+            return
+
         URL_REGEX = "https?://[^\\s\"')]+"
         result = view.find_all(URL_REGEX, sublime.IGNORECASE)
         

--- a/PlainTasks.py
+++ b/PlainTasks.py
@@ -756,6 +756,29 @@ class PlainTasksRemoveBold(sublime_plugin.TextCommand):
                 self.view.erase(edit, r)
 
 
+class PlainTasksShortenURL(sublime_plugin.EventListener):
+    def on_activated(self, view):
+        self.fold_all_urls(view)
+
+    def on_save(self, view):
+        self.fold_all_urls(view)
+
+    def fold_all_urls(self, view):
+        URL_REGEX = "https?://[^\\s\"')]+"
+        result = view.find_all(URL_REGEX, sublime.IGNORECASE)
+        
+        def only_appendix_region(url_region):
+            url = view.substr(url_region)
+            offset_match = re.search("^https?://[^/]+/", url)
+            if offset_match:
+                print(offset_match.span()[1])
+                return sublime.Region(url_region.a + offset_match.span()[1], url_region.b)
+            return url_region
+
+        without_domain = [only_appendix_region(region) for region in result]
+        view.fold(without_domain)
+
+
 class PlainTasksStatsStatus(sublime_plugin.EventListener):
     def on_activated(self, view):
         if not view.score_selector(0, "text.todo") > 0:

--- a/Readme.md
+++ b/Readme.md
@@ -203,6 +203,7 @@ Here is a list of PlainTasks’ specific settings:
 | **due_preview_offset**         | 0                | Place preview date outside of parens of `@due()`, 1 — within            |
 | **due_remain_format**          | `"{time} remaining"` | `{time}` will be replaced with actual value                         |
 | **due_overdue_format**         | `"{time} overdue"` | `{time}` will be replaced with actual value                           |
+| **shorten_urls**               | false    | If true, URLs are rendered as collapsed sections (`...`) after the domain name. |
 
 <b>¹</b> Icon value can be  `"dot"`, `"circle"`, `"bookmark"`, `"cross"`, `""`, or custom relative path to existing png file,
 e.g. `"Packages/User/my-icon.png"`.


### PR DESCRIPTION
I added a setting to visually shorten urls after they were typed. The feature is disabled by default and can be set in the settings.

<img width="519" alt="Screenshot 2020-04-14 at 12 47 32" src="https://user-images.githubusercontent.com/279378/79218041-156a6880-7e50-11ea-974a-d54e918f21dd.png">
