### PR TITLE
docs: fix simple typo, ommited -> omitted

### DIFF
--- a/PlainTasksDates.py
+++ b/PlainTasksDates.py
@@ -141,7 +141,7 @@ def increase_date(view, region, text, now, date_format):
     hour   = int(match_obj.group('hour') or 0)
     minute = int(match_obj.group('minute') or 0)
     if not (number or hour or minute) or (not number and (days or weeks)):
-        # set 1 if number is ommited, i.e.
+        # set 1 if number is omitted, i.e.
         #   @due(+) == @due(+1) == @due(+1d)
         #   @due(+w) == @due(+1w)
         number = 1


### PR DESCRIPTION
There is a small typo in PlainTasksDates.py.

Should read `omitted` rather than `ommited`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md