### PR TITLE
removed  a comparison-to-literal pitfall

### DIFF
--- a/plist_parser.py
+++ b/plist_parser.py
@@ -79,7 +79,7 @@ class XmlPropertyListParser(object):
     def endDocument(self):
         self._assert(self.__plist is not None, "A top level element must be <plist>.")
         self._assert(
-            len(self.__stack) is 0,
+            len(self.__stack) == 0,
             "multiple objects at top level.")
 
     def startElement(self, name, attributes):


### PR DESCRIPTION
**The problem**
The code was relying in a comparison-to-literal pitfall, which is described on the Pylint linter via the code  R0123

**Solution**
Refactored the code changing a single line