### PR TITLE
Commands for adding due date and sorting by due date/priority

### DIFF
--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -1,4 +1,7 @@
 [
     { "caption": "Tasks: Filter by tags under cursors", "command": "plain_tasks_fold_to_tags" },
-    { "caption": "Tasks: Show date picker", "command": "plain_tasks_calendar" }
+    { "caption": "Tasks: Show date picker", "command": "plain_tasks_calendar" },
+    { "caption": "Tasks: Add due date tag", "command": "plain_tasks_inject_due_date" },
+    { "caption": "Tasks: Sort items in the list under cursor by due date and priority", "command": "plain_tasks_sort_by_due_date_and_priority" },
+    { "caption": "Tasks: Reverse sort items in the list under cursor by due date and priority", "command": "plain_tasks_sort_by_due_date_and_priority", "args": {"descending": true} }
 ]

--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -9,6 +9,9 @@
   { "keys": ["ctrl+shift+u"], "command": "plain_tasks_open_url","context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }] },
   { "keys": ["alt+o"], "command": "plain_tasks_open_link","context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }] },
   { "keys": ["ctrl+shift+r"], "command": "plain_tasks_goto_tag", "context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }] },
+  { "keys": ["f4"], "command": "plain_tasks_inject_due_date","context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }] },
+  { "keys": ["f5"], "command": "plain_tasks_sort_by_due_date_and_priority","context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }] },
+  { "keys": ["f7"], "command": "plain_tasks_sort_by_due_date_and_priority","context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }], "args": {"descending": true} },
   { "keys": ["tab"], "command": "plain_task_insert_date", "context":
     [
       { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -9,6 +9,9 @@
   { "keys": ["super+shift+u"], "command": "plain_tasks_open_url","context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }] },
   { "keys": ["ctrl+o"], "command": "plain_tasks_open_link","context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }] },
   { "keys": ["super+shift+r"], "command": "plain_tasks_goto_tag", "context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }] },
+  { "keys": ["f4"], "command": "plain_tasks_inject_due_date","context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }] },
+  { "keys": ["f5"], "command": "plain_tasks_sort_by_due_date_and_priority","context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }] },
+  { "keys": ["f7"], "command": "plain_tasks_sort_by_due_date_and_priority","context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }], "args": {"descending": true} },
   { "keys": ["tab"], "command": "plain_task_insert_date", "context":
     [
       { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -9,6 +9,9 @@
   { "keys": ["ctrl+shift+u"], "command": "plain_tasks_open_url","context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }] },
   { "keys": ["alt+o"], "command": "plain_tasks_open_link","context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }] },
   { "keys": ["ctrl+shift+r"], "command": "plain_tasks_goto_tag", "context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }] },
+  { "keys": ["f4"], "command": "plain_tasks_inject_due_date","context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }] },
+  { "keys": ["f5"], "command": "plain_tasks_sort_by_due_date_and_priority","context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }] },
+  { "keys": ["f7"], "command": "plain_tasks_sort_by_due_date_and_priority","context": [{ "key": "selector", "operator": "equal", "operand": "text.todo" }], "args": {"descending": true} },
   { "keys": ["tab"], "command": "plain_task_insert_date", "context":
     [
       { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -12,5 +12,8 @@
     { "caption": "Tasks: Save as HTML…", "command": "plain_tasks_convert_to_html", "args": {"ask": true} },
     { "caption": "Tasks: Copy Statistics", "command": "plain_tasks_copy_stats" },
     { "caption": "Tasks: Fold to due tasks", "command": "plain_tasks_fold_to_due_tags" },
-    { "caption": "Tasks: Filter by tags under cursors", "command": "plain_tasks_fold_to_tags" }
+    { "caption": "Tasks: Filter by tags under cursors", "command": "plain_tasks_fold_to_tags" },
+    { "caption": "Tasks: Add due date tag", "command": "plain_tasks_inject_due_date" },
+    { "caption": "Tasks: Sort items in the list under cursor by due date and priority", "command": "plain_tasks_sort_by_due_date_and_priority" },
+    { "caption": "Tasks: Reverse sort items in the list under cursor by due date and priority", "command": "plain_tasks_sort_by_due_date_and_priority", "args": {"descending": true} }
 ]

--- a/PlainTasksDates.py
+++ b/PlainTasksDates.py
@@ -554,7 +554,7 @@ class PlainTasksChooseDate(sublime_plugin.ViewEventListener):
 
 class PlainTasksCalendar(sublime_plugin.TextCommand):
     def is_visible(self):
-        return ST3
+        return self.view.score_selector(0, "text.todo") > 0
 
     def run(self, edit, point=None):
         point = point or self.view.sel()[0].a


### PR DESCRIPTION
A command for adding due date is useful in Sublime Text 4 as the completion menu offers quite a few choices and the snippet for inserting the due date is not the first choice in the menu (when doing d+TAB). The command instead is one key away all the time. Adding due date is bound to F4 key by default. It supports multiple cursors too.

Sorting by due date and priority works by first sorting by due date (and leaving the items without a due date at the end and secondly sorting by priority with the following order: @critical, @high, normal (doesn't exist so any task without other priority tags is considered normal priority), and lastly @low. Sorting is done only on the first level allowing fine control on what to sort, nested lists are supported and just the list to be sorted can be picked. To sort you have to place the cursor on the header of target list. Sorting is bound to F5 by default. It supports multiple cursors too (being able to sort multiple lists at once).

Reverse sorting is also supported and is bound by default to F7.