### PR TITLE
Adds support for the X symbol ❌ for canceled tasks

### DIFF
--- a/PlainTasks (Linux).sublime-settings
+++ b/PlainTasks (Linux).sublime-settings
@@ -1,7 +1,7 @@
 {
   "open_tasks_bullet": "☐", // options: - | ❍ | ❑ | ■ | □ | ☐ | ▪ | ▫ | – | — | ≡ | → | › | [ ]
   "done_tasks_bullet": "✔", // options: + | ✓ | ✔ | √ | [x]
-  "cancelled_tasks_bullet": "✘", // options: x | ✘ | [-]
+  "cancelled_tasks_bullet": "✘", // options: x | ✘ | [-] | ❌
   "before_tasks_bullet_margin": 1,
   "date_format": "(%y-%m-%d %H:%M)",
   "done_tag": true, // related to @cancelled as well

--- a/PlainTasks (OSX).sublime-settings
+++ b/PlainTasks (OSX).sublime-settings
@@ -1,7 +1,7 @@
 {
   "open_tasks_bullet": "☐", // options: - | ❍ | ❑ | ■ | □ | ☐ | ▪ | ▫ | – | — | ≡ | → | › | [ ]
   "done_tasks_bullet": "✔", // options: + | ✓ | ✔ | √ | [x]
-  "cancelled_tasks_bullet": "✘", // options: x | ✘ | [-]
+  "cancelled_tasks_bullet": "✘", // options: x | ✘ | [-] | ❌
   "before_tasks_bullet_margin": 1,
   "date_format": "(%y-%m-%d %H:%M)",
   "done_tag": true, // related to @cancelled as well

--- a/PlainTasks (Windows).sublime-settings
+++ b/PlainTasks (Windows).sublime-settings
@@ -1,7 +1,7 @@
 {
   "open_tasks_bullet": "☐", // options: - | ❍ | ❑ | ■ | □ | ☐ | ▪ | ▫ | – | — | ≡ | → | › | [ ]
   "done_tasks_bullet": "✔", // options: + | ✓ | ✔ | √ | [x]
-  "cancelled_tasks_bullet": "✘", // options: x | ✘ | [-]
+  "cancelled_tasks_bullet": "✘", // options: x | ✘ | [-] | ❌
   "before_tasks_bullet_margin": 1,
   "date_format": "(%y-%m-%d %H:%M)",
   "done_tag": true, // related to @cancelled as well

--- a/PlainTasks.sublime-syntax
+++ b/PlainTasks.sublime-syntax
@@ -19,7 +19,7 @@ contexts:
         4: punctuation.definition.bullet.completed.todo
         5: comment.line.completed.todo
         6: meta.tag.todo.completed
-    - match: '^\s*(?:(✘|x|\[-\])(\s+(?:[^\@\n]|(?<!\s)\@|\@(?=\s))*)(.*))|^\s*(?:(-)(\s+(?:[^\@]|(?<!\s)\@|\@(?=\s))*)(.*\@cancelled(?=\s|\(|$)[^\n]*))'
+    - match: '^\s*(?:(✘|❌|x|\[-\])(\s+(?:[^\@\n]|(?<!\s)\@|\@(?=\s))*)(.*))|^\s*(?:(-)(\s+(?:[^\@]|(?<!\s)\@|\@(?=\s))*)(.*\@cancelled(?=\s|\(|$)[^\n]*))'
       scope: meta.item.todo.cancelled
       captures:
         1: punctuation.definition.bullet.cancelled.todo
@@ -28,7 +28,7 @@ contexts:
         4: punctuation.definition.bullet.cancelled.todo
         5: text.cancelled.todo
         6: meta.tag.todo.cancelled
-    - match: '^\s*(?!-|\+|✓|✔|√|❍|❑|■|□|☐|▪|▫|–|—|≡|→|›|\[[\sx-]\]|＿|✘|(x\s+))(?=\S)'
+    - match: '^\s*(?!-|\+|✓|✔|√|❍|❑|■|□|☐|▪|▫|–|—|≡|→|›|\[[\sx-]\]|＿|✘|❌|(x\s+))(?=\S)'
       push:
         - meta_scope: notes.todo
         - match: $\n?

--- a/PlainTasks.tmLanguage
+++ b/PlainTasks.tmLanguage
@@ -96,14 +96,14 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>^\s*(?:(✘|x|\[-\])(\s+(?:[^\@\n]|(?&lt;!\s)\@|\@(?=\s))*)(.*))|^\s*(?:(-)(\s+(?:[^\@]|(?&lt;!\s)\@|\@(?=\s))*)(.*\@cancelled(?=\s|\(|$)[^\n]*))</string>
+			<string>^\s*(?:(✘|❌|x|\[-\])(\s+(?:[^\@\n]|(?&lt;!\s)\@|\@(?=\s))*)(.*))|^\s*(?:(-)(\s+(?:[^\@]|(?&lt;!\s)\@|\@(?=\s))*)(.*\@cancelled(?=\s|\(|$)[^\n]*))</string>
 			<key>name</key>
 			<string>meta.item.todo.cancelled</string>
 		</dict>
 
 		<dict>
 		  <key>begin</key>
-		  <string>^\s*(?!-|\+|✓|✔|√|❍|❑|■|□|☐|▪|▫|–|—|≡|→|›|\[[\sx-]\]|＿|✘|(x\s+))(?=\S)</string>
+		  <string>^\s*(?!-|\+|✓|✔|√|❍|❑|■|□|☐|▪|▫|–|—|≡|→|›|\[[\sx-]\]|＿|✘|❌|(x\s+))(?=\S)</string>
 		  <key>end</key>
 		  <string>$\n?</string>
 		  <key>name</key>


### PR DESCRIPTION
This PR adds support for the X symbol ❌ for canceled tasks.

![image](https://github.com/aziz/PlainTasks/assets/19473342/29c7cd3c-41ca-4906-847b-2de51fb86c87)

The old default symbol ✘ had a few issues:
- not same style as the default ✔
- different width, causing task lists to be misaligned
- behaved differently on normal lines, becoming gray, unlike the checkmark

Simply swapping the new X symbol in the preferences under `"cancelled_tasks_bullet": "✘", // options: x | ✘ | [-]` caused issues, with the count of tasks at the bottom not working correctly and neither shortcuts.

The default canceled symbol is not changed so no behavior is changed for users. Users now have the option to switch to the new symbol if they like by updating their preferences.

